### PR TITLE
feat: Add SetData functionality for writing simulation variables

### DIFF
--- a/cmd/camera_test/main.go
+++ b/cmd/camera_test/main.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/mrlm-net/go-simconnect/pkg/client"
+)
+
+func main() {
+	fmt.Println("=== 📹 CAMERA CONTROL TEST ===")
+	fmt.Println("This test will cycle through different camera views")
+	fmt.Println("👀 Watch for IMMEDIATE camera changes in MSFS 2024!")
+	fmt.Println("🎯 This is the DEFINITIVE test for SetData functionality")
+	fmt.Println()
+
+	// Create SimConnect client with MSFS 2024 SDK path
+	dllPath := `C:\MSFS 2024 SDK\SimConnect SDK\lib\SimConnect.dll`
+	simClient := client.NewClientWithDLLPath("CameraTest", dllPath)
+
+	// Connect to SimConnect
+	fmt.Println("🔗 Connecting to SimConnect...")
+	if err := simClient.Open(); err != nil {
+		log.Fatalf("❌ Failed to connect to SimConnect: %v", err)
+	}
+	defer simClient.Close()
+	fmt.Println("✅ Connected successfully")
+
+	// Create flight data manager
+	fdm := client.NewFlightDataManager(simClient)
+
+	// Add camera state variable (writable)
+	fmt.Println("📝 Adding Camera State variable...")
+	if err := fdm.AddVariableWithWritable("Camera State", "Camera State", "number", true); err != nil {
+		log.Fatalf("❌ Failed to add camera state variable: %v", err)
+	}
+	fmt.Println("✅ Camera State variable added")
+
+	// Start data collection
+	fmt.Println("🚀 Starting data monitoring...")
+	if err := fdm.Start(); err != nil {
+		log.Fatalf("❌ Failed to start data collection: %v", err)
+	}
+	defer fdm.Stop()
+
+	// Wait for initial data
+	fmt.Println("⏱️ Waiting for initial data...")
+	time.Sleep(3 * time.Second)
+
+	// Check current camera state
+	cameraVar, found := fdm.GetVariable("Camera State")
+	if !found {
+		log.Fatal("❌ Camera State variable not found")
+	}
+
+	fmt.Printf("📊 Current Camera State: %.0f\n", cameraVar.Value)
+	fmt.Println()
+
+	// Camera test sequence with 15 second pauses
+	cameraSequence := []struct {
+		state       float64
+		description string
+		viewName    string
+	}{
+		{2.0, "🏠 Switching to COCKPIT view", "Cockpit"},
+		{3.0, "🌍 Switching to EXTERNAL view", "External"},
+		{4.0, "🪶 Switching to WING view", "Wing"},
+		{5.0, "🚁 Switching to TAIL view", "Tail"},
+		{6.0, "🗼 Switching to TOWER view", "Tower"},
+		{2.0, "🏠 Returning to COCKPIT view", "Cockpit"},
+	}
+
+	fmt.Println("🎬 Starting Camera Control Test Sequence!")
+	fmt.Println("⏰ Each camera change will last 15 seconds")
+	fmt.Println("👁️ Watch your simulator screen for IMMEDIATE camera changes!")
+	fmt.Println()
+
+	for i, step := range cameraSequence {
+		fmt.Printf("📹 Step %d: %s (State %.0f)\n", i+1, step.description, step.state)
+		fmt.Printf("   🎯 Target: %s View\n", step.viewName)
+		
+		// Send the camera change command
+		fmt.Printf("   🎛️  Setting camera state to: %.0f\n", step.state)
+		if err := fdm.SetVariable("Camera State", step.state); err != nil {
+			fmt.Printf("   ❌ ERROR: %v\n", err)
+			continue
+		}
+		fmt.Printf("   ✅ SetData command sent successfully\n")
+
+		// Brief pause to let the command take effect
+		time.Sleep(1 * time.Second)
+
+		// Read back the camera state to verify
+		cameraVar, found := fdm.GetVariable("Camera State")
+		if found {
+			fmt.Printf("   📖 Camera State readback: %.0f\n", cameraVar.Value)
+			
+			if cameraVar.Value == step.state {
+				fmt.Printf("   🎯 SUCCESS: Camera state changed to %.0f (%s) as expected\n", step.state, step.viewName)
+			} else {
+				fmt.Printf("   ⚠️  Note: Expected %.0f but got %.0f (may take time to update)\n", step.state, cameraVar.Value)
+			}
+		} else {
+			fmt.Printf("   ❌ ERROR: Could not read camera state\n")
+		}
+
+		fmt.Printf("   👀 LOOK AT YOUR SIMULATOR NOW - Should be in %s view!\n", step.viewName)
+		fmt.Printf("   ⏰ Observing for 15 seconds...\n")
+		fmt.Println()
+
+		// Wait 15 seconds for visual observation
+		for countdown := 15; countdown > 0; countdown-- {
+			if countdown%5 == 0 || countdown <= 3 {
+				fmt.Printf("   ⏳ %d seconds remaining in %s view...\n", countdown, step.viewName)
+			}
+			time.Sleep(1 * time.Second)
+		}
+
+		fmt.Println("   ✅ Observation period complete")
+		fmt.Println()
+	}
+
+	fmt.Println("🏁 Camera Control Test Sequence COMPLETED!")
+	fmt.Println()
+	
+	// Final verification
+	cameraVar, found = fdm.GetVariable("Camera State")
+	if found {
+		var viewName string
+		switch cameraVar.Value {
+		case 2:
+			viewName = "Cockpit"
+		case 3:
+			viewName = "External"
+		case 4:
+			viewName = "Wing"
+		case 5:
+			viewName = "Tail"
+		case 6:
+			viewName = "Tower"
+		default:
+			viewName = fmt.Sprintf("Unknown (%.0f)", cameraVar.Value)
+		}
+		fmt.Printf("🎯 Final Camera State: %.0f (%s)\n", cameraVar.Value, viewName)
+	}
+	fmt.Println()
+
+	// Results evaluation
+	fmt.Println("📊 TEST RESULTS EVALUATION:")
+	fmt.Println("✅ If you saw the camera views changing every 15 seconds:")
+	fmt.Println("   → SetData is WORKING PERFECTLY! 🎉")
+	fmt.Println("   → Commands are reaching the simulator!")
+	fmt.Println("   → go-simconnect SetData implementation is VALIDATED!")
+	fmt.Println()
+	fmt.Println("❌ If camera views did NOT change:")
+	fmt.Println("   → SetData may not be working properly")
+	fmt.Println("   → Need to investigate further")
+	fmt.Println()
+	fmt.Println("🔄 Continuous monitoring (Press Ctrl+C to exit):")
+	fmt.Println("Monitoring camera state for any changes...")
+
+	// Continue monitoring camera state
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			cameraVar, found := fdm.GetVariable("Camera State")
+			if found {
+				var viewName string
+				switch cameraVar.Value {
+				case 2:
+					viewName = "Cockpit"
+				case 3:
+					viewName = "External"
+				case 4:
+					viewName = "Wing"
+				case 5:
+					viewName = "Tail"
+				case 6:
+					viewName = "Tower"
+				default:
+					viewName = fmt.Sprintf("Unknown (%.0f)", cameraVar.Value)
+				}
+				
+				age := time.Since(cameraVar.Updated)
+				fmt.Printf("[%s] Camera: %.0f (%s) - Updated %v ago\n", 
+					time.Now().Format("15:04:05"), 
+					cameraVar.Value, 
+					viewName,
+					age.Truncate(time.Second))
+			}
+		}
+	}
+}

--- a/docs/SetDataImplementation.md
+++ b/docs/SetDataImplementation.md
@@ -1,0 +1,234 @@
+# SimConnect SetDataOnSimObject Implementation
+
+This document describes the implementation of `SetDataOnSimObject` functionality in the go-simconnect library, enabling both reading and writing of simulation variables.
+
+## Overview
+
+The implementation allows you to:
+- ✅ **Read** simulation variables (existing functionality)
+- ✅ **Write** simulation variables (new functionality)
+- ✅ **Control which variables are writable** (safety feature)
+- ✅ **Use both individual and batch operations**
+
+## Architecture Decision: Non-Tagged Mode
+
+### The Question: Tagged vs Non-Tagged Data Setting
+
+SimConnect supports two modes for setting data:
+- **Non-Tagged Mode (Default)**: Replace entire data definition with new data
+- **Tagged Mode**: Send data in tagged format for selective updates
+
+### Our Decision: Non-Tagged Mode
+
+**Why we chose non-tagged mode:**
+
+1. **Individual Variable Architecture**: Our system creates separate `DataDefinitionID` for each variable
+2. **Granular Control**: We want to set individual variables independently  
+3. **Simplicity**: Non-tagged mode is simpler and more predictable
+4. **Consistency**: Matches our existing read architecture
+
+**Example of our approach:**
+```go
+// Each variable gets its own data definition
+defineID := DataDefinitionID(1)  // Throttle
+defineID := DataDefinitionID(2)  // Flaps
+defineID := DataDefinitionID(3)  // Gear
+
+// Set individual variables using non-tagged mode
+fdm.SetVariable("Throttle Position", 75.0)  // Only affects throttle
+fdm.SetVariable("Flaps Position", 25.0)     // Only affects flaps
+```
+
+This approach ensures that setting one variable never accidentally affects another.
+
+## Implementation Details
+
+### 1. Constants Added
+
+```go
+// SimConnect data set flags for SetDataOnSimObject
+type SIMCONNECT_DATA_SET_FLAG uint32
+
+const (
+    SIMCONNECT_DATA_SET_FLAG_DEFAULT SIMCONNECT_DATA_SET_FLAG = 0  // Non-tagged mode
+    SIMCONNECT_DATA_SET_FLAG_TAGGED  SIMCONNECT_DATA_SET_FLAG = 1  // Tagged mode
+)
+```
+
+### 2. Core Client Functions
+
+**Low-level function:**
+```go
+func (c *Client) SetDataOnSimObject(
+    defineID DataDefinitionID, 
+    objectID SIMCONNECT_OBJECT_ID, 
+    flags SIMCONNECT_DATA_SET_FLAG, 
+    data []byte,
+) error
+```
+
+**Convenience functions:**
+```go
+func (c *Client) SetFloat64OnSimObject(defineID DataDefinitionID, objectID SIMCONNECT_OBJECT_ID, value float64) error
+func (c *Client) SetFloat32OnSimObject(defineID DataDefinitionID, objectID SIMCONNECT_OBJECT_ID, value float32) error  
+func (c *Client) SetInt32OnSimObject(defineID DataDefinitionID, objectID SIMCONNECT_OBJECT_ID, value int32) error
+```
+
+### 3. FlightDataManager Extensions
+
+**Enhanced FlightVariable:**
+```go
+type FlightVariable struct {
+    Name     string    // Human-readable name
+    SimVar   string    // SimConnect variable name
+    Units    string    // Units of measurement
+    Value    float64   // Current value
+    Updated  time.Time // Last update time
+    Writable bool      // Whether this variable can be written to (NEW)
+}
+```
+
+**New methods:**
+```go
+// Add variables with write capability
+func (fdm *FlightDataManager) AddVariableWithWritable(name, simVar, units string, writable bool) error
+
+// Set variables by name
+func (fdm *FlightDataManager) SetVariable(name string, value float64) error
+
+// Set variables by index (more efficient)
+func (fdm *FlightDataManager) SetVariableByIndex(index int, value float64) error
+
+// Add common writable variables
+func (fdm *FlightDataManager) AddWritableStandardVariables() error
+```
+
+## Usage Examples
+
+### Basic Usage
+
+```go
+// Create client and flight data manager
+simClient := client.NewClient("MyApp")
+simClient.Open()
+fdm := client.NewFlightDataManager(simClient)
+
+// Add writable variables
+fdm.AddVariableWithWritable("Throttle Position", "General Eng Throttle Lever Position:1", "percent", true)
+fdm.AddVariableWithWritable("Flaps Position", "Flaps Handle Percent", "percent", true)
+
+// Add read-only variables  
+fdm.AddVariable("Altitude", "Plane Altitude", "feet")
+
+// Start data collection
+fdm.Start()
+
+// Set values
+fdm.SetVariable("Throttle Position", 75.0)  // Set throttle to 75%
+fdm.SetVariable("Flaps Position", 25.0)     // Set flaps to 25%
+
+// Reading values still works as before
+if variable, found := fdm.GetVariable("Altitude"); found {
+    fmt.Printf("Current altitude: %.0f feet\n", variable.Value)
+}
+```
+
+### Advanced Usage
+
+```go
+// Add commonly writable variables all at once
+fdm.AddWritableStandardVariables()
+
+// More efficient repeated operations using index
+throttleIndex := 0  // Assuming throttle is first writable variable
+for i := 0; i <= 100; i += 10 {
+    fdm.SetVariableByIndex(throttleIndex, float64(i))
+    time.Sleep(100 * time.Millisecond)
+}
+```
+
+### Error Handling
+
+```go
+// The system prevents setting read-only variables
+err := fdm.SetVariable("Altitude", 5000.0)  
+if err != nil {
+    fmt.Printf("Expected error: %v\n", err)  // "variable 'Altitude' is not writable"
+}
+
+// Check if variable is writable before setting
+if variable, found := fdm.GetVariable("Throttle Position"); found && variable.Writable {
+    fdm.SetVariable("Throttle Position", 50.0)
+}
+```
+
+## Commonly Writable Variables
+
+The implementation includes these commonly writable variables:
+
+| Variable Name | SimConnect Variable | Units | Description |
+|--------------|-------------------|-------|-------------|
+| Throttle Position | General Eng Throttle Lever Position:1 | percent | Engine throttle |
+| Flaps Position | Flaps Handle Percent | percent | Wing flaps |
+| Gear Position | Gear Handle Position | bool | Landing gear |
+| Mixture Position | General Eng Mixture Lever Position:1 | percent | Fuel mixture |
+| Autopilot Master | Autopilot Master | bool | Autopilot on/off |
+| Autopilot Altitude Lock | Autopilot Altitude Lock | bool | Altitude hold |
+| Autopilot Heading Lock | Autopilot Heading Lock | bool | Heading hold |
+
+## Safety Features
+
+1. **Write Protection**: Variables must be explicitly marked as writable
+2. **Validation**: Check variable exists and is writable before setting
+3. **Error Handling**: Comprehensive error reporting
+4. **Individual Control**: Each variable has its own data definition
+5. **Thread Safety**: All operations are thread-safe
+
+## Testing
+
+Run the comprehensive test to validate the implementation:
+
+```bash
+cd cmd/comprehensive_test
+./comprehensive_test.exe
+```
+
+The test will:
+- Connect to SimConnect
+- Add both readable and writable variables
+- Demonstrate setting various control surfaces
+- Show error handling for read-only variables
+- Monitor values in real-time
+
+## Technical Notes
+
+### Why Non-Tagged Mode Works for Us
+
+1. **Separate Data Definitions**: Each variable has its own `DataDefinitionID`
+2. **Single Value Operations**: We typically set one variable at a time
+3. **Clear Boundaries**: No risk of overwriting other variables
+4. **Simplicity**: Easier to understand and debug
+
+### Performance Considerations
+
+1. **Individual Calls**: Each `SetVariable` call results in one SimConnect API call
+2. **Efficient Index Access**: Use `SetVariableByIndex` for repeated operations
+3. **Batch Operations**: For multiple changes, consider grouping them in time
+4. **Thread Safety**: All operations are protected by mutexes
+
+### Limitations
+
+1. **Single Aircraft**: Currently targets `SIMCONNECT_OBJECT_ID_USER` (user's aircraft)
+2. **Float64 Focus**: Optimized for float64 values (most flight sim variables)
+3. **No Tagged Mode**: Does not support tagged format (by design choice)
+4. **SimConnect Dependency**: Requires Microsoft Flight Simulator running
+
+## Future Enhancements
+
+Potential improvements for future versions:
+- Support for multiple aircraft (AI aircraft)
+- Batch setting operations
+- Tagged mode support (if needed)
+- More data type helpers (strings, complex structures)
+- Validation of value ranges
+- Undo/redo functionality

--- a/pkg/client/constants.go
+++ b/pkg/client/constants.go
@@ -67,3 +67,11 @@ const (
 // Data definition and request ID types
 type DataDefinitionID uint32
 type SimObjectDataRequestID uint32
+
+// SimConnect data set flags for SetDataOnSimObject
+type SIMCONNECT_DATA_SET_FLAG uint32
+
+const (
+	SIMCONNECT_DATA_SET_FLAG_DEFAULT SIMCONNECT_DATA_SET_FLAG = 0
+	SIMCONNECT_DATA_SET_FLAG_TAGGED  SIMCONNECT_DATA_SET_FLAG = 1
+)


### PR DESCRIPTION
 NEW FEATURES:
- Implemented SetDataOnSimObject for writing simulation variables
- Added convenience methods: SetFloat64OnSimObject, SetFloat32OnSimObject, SetInt32OnSimObject
- Extended FlightDataManager with SetVariable and SetVariableByIndex methods
- Added SIMCONNECT_DATA_SET_FLAG constants for non-tagged mode
- Implemented write protection with Writable field in FlightVariable

 VALIDATED FUNCTIONALITY:
- Camera control test provides immediate visual feedback
- Confirmed SetData commands reach and control MSFS 2024 systems
- Tested with multiple aircraft systems (lights, battery, camera)
- All SetData operations working with real-time state changes

 DOCUMENTATION:
- Complete technical documentation in docs/SetDataImplementation.md
- Updated README with camera control example
- Added comprehensive API documentation for new methods

 ARCHITECTURE:
- Non-tagged mode implementation for safety and simplicity
- Thread-safe operations with proper error handling
- Individual DataDefinitionID per variable for isolation
- Maintains backward compatibility with existing read functionality

 EXAMPLES:
- Camera test as definitive validation example (cmd/camera_test/)
- Removed temporary test files, kept only production-ready examples
- Immediate visual feedback for SetData validation

closing #4 